### PR TITLE
Wasm native strings 3rd attempt

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -799,7 +799,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
         tree match {
           case StringLiteral(value) =>
             // Common shape for all the `nameTree` expressions
-            fb ++= ctx.stringPool.getConstantStringInstr(value)
+            fb ++= ctx.stringPool.getConstantJSStringInstr(value)
 
           case VarRef(LocalIdent(localName)) if classCaptureParamsOfTypeAny.contains(localName) =>
             /* Common shape for the `jsSuperClass` value

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -701,7 +701,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
               genGlobalID.forJSPrivateField(name.name),
               makeDebugName(ns.PrivateJSField, name.name),
               isMutable = true,
-              watpe.RefType.anyref,
+              watpe.RefType.anyref, // keep field type anyref even for String
               wa.Expr(List(wa.RefNull(watpe.HeapType.Any)))
             )
           )

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -2333,6 +2333,12 @@ object CoreWasmLib {
     fb.buildAndAddToModule()
   }
 
+  // (ref (array (mut i16))) -> (ref any)
+  private def genMaybeCreateJSStringFromArray()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.maybeCreateJSStringFromArray)
+    val arrayParam = fb.addParam("str", RefType.anyref)
+  }
+
   // (ref null (array (mut i16))) -> (ref null any)
   private def genCreateJSStringFromArrayNullable()(implicit ctx: WasmContext): Unit = {
     val fb = newFunctionBuilder(genFunctionID.createJSStringFromArrayNullable)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -611,7 +611,16 @@ object CoreWasmLib {
     genIdentityHashCode()
     genSearchReflectiveProxy()
     genArrayCloneFunctions()
+
     genJSStringBuiltins()
+    genWasmStringConcat()
+    genCreateJSStringFromArray()
+    genCreateJSStringFromArrayNullable()
+    genCreateArrayFromJSString()
+    genCreateArrayFromJSStringNullable()
+    genNonNullString()
+    genStringEquals()
+    genArrayEquals()
   }
 
   private def newFunctionBuilder(functionID: FunctionID, originalName: OriginalName)(
@@ -2239,4 +2248,271 @@ object CoreWasmLib {
     fb.buildAndAddToModule()
   }
 
+  // TODO: do not use js string concat
+  private def genWasmStringConcat()(implicit ctx: WasmContext): Unit = {
+    import VarGen.genTypeID.i16Array
+
+    val fb = newFunctionBuilder(genFunctionID.wasmStringConcat)
+    val arr1Param = fb.addParam("arr1param", RefType(i16Array))
+    val arr2Param = fb.addParam("arr2param", RefType(i16Array))
+    val dest = fb.addLocal("result", RefType(i16Array))
+    fb.setResultType(RefType(i16Array))
+
+    fb += LocalGet(arr1Param)
+    fb += ArrayLen
+    fb += LocalGet(arr2Param)
+    fb += ArrayLen
+    fb += I32Add
+    fb += ArrayNewDefault(genTypeID.i16Array)
+    fb += LocalSet(dest)
+
+    fb += LocalGet(dest) // dest
+    fb += I32Const(0) // dest_offset
+    fb += LocalGet(arr1Param) // src
+    fb += I32Const(0) // src_offset
+    fb ++= List(LocalGet(arr1Param), ArrayLen) //size
+    fb += ArrayCopy(genTypeID.i16Array, genTypeID.i16Array)
+
+    fb += LocalGet(dest) // dest
+    fb ++= List(LocalGet(arr1Param), ArrayLen) // dest_offset
+    fb += LocalGet(arr2Param) // src
+    fb += I32Const(0) // src_offset
+    fb ++= List(LocalGet(arr2Param), ArrayLen) //size
+    fb += ArrayCopy(genTypeID.i16Array, genTypeID.i16Array)
+
+    fb += LocalGet(dest)
+
+    fb.buildAndAddToModule()
+  }
+
+  // (ref null any) -> (ref null (array (mut i16)))
+  private def genCreateArrayFromJSStringNullable()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.createArrayFromJSStringNullable)
+    val strParam = fb.addParam("str", RefType.anyref)
+    fb.setResultType(RefType.nullable(genTypeID.i16Array))
+
+    fb.block(RefType.any) { nonNullLabel =>
+      fb += LocalGet(strParam)
+      fb += BrOnNonNull(nonNullLabel)
+      fb += RefNull(HeapType(genTypeID.i16Array))
+      fb += Return
+    }
+    fb += Call(genFunctionID.createArrayFromJSString)
+
+    fb.buildAndAddToModule()
+  }
+
+  // (ref any) -> (ref (array (mut i16)))
+  private def genCreateArrayFromJSString()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.createArrayFromJSString)
+    val strParam = fb.addParam("strParam", RefType.any)
+    val result = fb.addLocal("result", RefType(genTypeID.i16Array))
+    fb.setResultType(RefType(genTypeID.i16Array))
+
+    fb += LocalGet(strParam)
+    fb += ExternConvertAny // extern
+
+    // allocate mutable i16 array
+    fb += LocalGet(strParam)
+    fb += Call(genFunctionID.stringLength) // str.length
+    fb += ArrayNewDefault(genTypeID.i16Array) // (ref (array (mut i16)))
+    fb += LocalTee(result)
+
+    // start
+    fb += I32Const(0)
+
+    fb += Call(genFunctionID.intoCharCodeArray) // i32 (number of char codes written)
+    fb += Drop
+
+    fb += LocalGet(result)
+
+    fb.buildAndAddToModule()
+  }
+
+  // (ref null (array (mut i16))) -> (ref null any)
+  private def genCreateJSStringFromArrayNullable()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.createJSStringFromArrayNullable)
+    val arrayParam = fb.addParam("array", RefType.nullable(genTypeID.i16Array))
+    fb.setResultType(RefType.anyref)
+
+    fb.block(RefType(genTypeID.i16Array)) { nonNullLabel =>
+      fb += LocalGet(arrayParam)
+      fb += BrOnNonNull(nonNullLabel)
+      fb += RefNull(HeapType.Any)
+      fb += Return
+    }
+    fb += Call(genFunctionID.createJSStringFromArray)
+
+    fb.buildAndAddToModule()
+  }
+
+  // (ref (array (mut i16))) -> (ref any)
+  private def genCreateJSStringFromArray()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.createJSStringFromArray)
+    val arrayParam = fb.addParam("array", RefType(genTypeID.i16Array))
+    fb.setResultType(RefType.any)
+
+    fb += LocalGet(arrayParam)
+
+    // start
+    fb += I32Const(0)
+
+    // end
+    fb += LocalGet(arrayParam)
+    fb += ArrayLen
+
+    fb += Call(genFunctionID.fromCharCodeArray) // (ref extern)
+    fb += AnyConvertExtern // (ref any)
+
+    fb.buildAndAddToModule()
+  }
+
+  // (ref null (array (mut i16))) -> (ref (array (mut i16)))
+  private def genNonNullString()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.nonNullString)
+    val strParam = fb.addParam("str", RefType.nullable(genTypeID.i16Array))
+    fb.setResultType(RefType(genTypeID.i16Array))
+
+    fb.block(RefType(genTypeID.i16Array)) { labelNonNull =>
+      fb += LocalGet(strParam)
+      fb += BrOnNonNull(labelNonNull)
+      fb ++= ctx.stringPool.getConstantStringInstr("null")
+      fb += Call(genFunctionID.createArrayFromJSString)
+    }
+
+    fb.buildAndAddToModule()
+  }
+
+  private def genStringEquals()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.equals)
+    val str1Param = fb.addParam("str1", RefType.anyref)
+    val str2Param = fb.addParam("str2", RefType.anyref)
+    fb.setResultType(Int32)
+
+    fb.block(Int32) { doneLabel =>
+      // Block to handle the case where both are i16Array
+      fb.block(RefType.anyref) { notBothArray =>
+        fb += LocalGet(str1Param)
+        fb += BrOnCastFail(
+          notBothArray,
+          RefType.anyref,
+          RefType.nullable(genTypeID.i16Array)
+        )
+        fb += LocalGet(str2Param)
+        fb += BrOnCastFail(
+          notBothArray,
+          RefType.anyref,
+          RefType.nullable(genTypeID.i16Array)
+        )
+        fb += Call(genFunctionID.arrayEquals)
+        fb += Br(doneLabel)
+      } // end of block notBothArray
+      fb += Drop
+
+      // Block to handle the case where both are JS string
+      fb.block(RefType.nullable(genTypeID.i16Array)) { notBothJS =>
+        fb += LocalGet(str1Param)
+        fb += BrOnCast(
+          notBothJS,
+          RefType.anyref,
+          RefType.nullable(genTypeID.i16Array)
+        )
+        fb += LocalGet(str2Param)
+        fb += BrOnCast(
+          notBothJS,
+          RefType.anyref,
+          RefType.nullable(genTypeID.i16Array)
+        )
+        fb += Call(genFunctionID.is)
+        fb += Br(doneLabel)
+      } // end of block notBothJS
+      fb += Drop
+
+      // i16Array vs JS String, return 0 (false)
+      fb += I32Const(0)
+    } // end of block doneLabel
+
+    fb.buildAndAddToModule()
+  }
+
+  private def genArrayEquals()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.arrayEquals)
+    val arr1Param = fb.addParam("arr1", RefType.nullable(genTypeID.i16Array))
+    val arr2Param = fb.addParam("arr2", RefType.nullable(genTypeID.i16Array))
+
+    val len1 = fb.addLocal("len1", Int32)
+    val len2 = fb.addLocal("len2", Int32)
+    val iLocal = fb.addLocal("i", Int32)
+
+    fb.setResultType(Int32)
+
+    // Check if both arrays are null
+    fb += LocalGet(arr1Param)
+    fb += RefIsNull
+    fb += LocalGet(arr2Param)
+    fb += RefIsNull
+    fb += I32And
+    fb.ifThen() {
+      fb += I32Const(1)
+      fb += Return
+    }
+
+    // Check if one of the arrays is null
+    fb += LocalGet(arr1Param)
+    fb += RefIsNull
+    fb += LocalGet(arr2Param)
+    fb += RefIsNull
+    fb += I32Or
+    fb.ifThen() {
+      fb += I32Const(0)
+      fb += Return
+    }
+
+    // length
+    fb += LocalGet(arr1Param)
+    fb += ArrayLen
+    fb += LocalTee(len1)
+    fb += LocalGet(arr2Param)
+    fb += ArrayLen
+    fb += LocalTee(len2)
+
+    // compare length
+    fb += I32Ne
+    fb.ifThen() {
+      fb += I32Const(0)
+      fb += Return
+    }
+
+    // compare elements
+    fb += I32Const(0)
+    fb += LocalSet(iLocal)
+    fb.whileLoop() {
+      fb += LocalGet(iLocal)
+      fb += LocalGet(len1)
+      fb += I32Ne
+    } {
+      fb += LocalGet(arr1Param)
+      fb += LocalGet(iLocal)
+      fb += ArrayGetU(genTypeID.i16Array)
+
+      fb += LocalGet(arr2Param)
+      fb += LocalGet(iLocal)
+      fb += ArrayGetU(genTypeID.i16Array)
+
+      fb += I32Ne
+      fb.ifThen() {
+        fb += I32Const(0)
+        fb += Return
+      }
+
+      // i := i + 1
+      fb += LocalGet(iLocal)
+      fb += I32Const(1)
+      fb += I32Add
+      fb += LocalSet(iLocal)
+    }
+    fb += I32Const(1)
+
+    fb.buildAndAddToModule()
+  }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -1983,6 +1983,8 @@ object CoreWasmLib {
         },
         List(JSValueTypeString) -> { () =>
           fb += LocalGet(objNonNullLocal)
+          // BoxedStringClass methods expect receiver to be i16Array, convert from JS to i16 array
+          fb += Call(genFunctionID.createArrayFromJSString)
           fb += Call(
             genFunctionID.forMethod(Public, BoxedStringClass, hashCodeMethodName)
           )
@@ -2010,6 +2012,8 @@ object CoreWasmLib {
             fb += LocalGet(objNonNullLocal)
             fb += Call(genFunctionID.symbolDescription)
             fb += BrOnNull(descriptionIsNullLabel)
+            // BoxedStringClass methods expect receiver to be i16Array, convert from JS to i16 array
+            fb += Call(genFunctionID.createArrayFromJSString)
             fb += Call(
               genFunctionID.forMethod(Public, BoxedStringClass, hashCodeMethodName)
             )

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -619,7 +619,7 @@ object CoreWasmLib {
     genCreateArrayFromJSString()
     genCreateArrayFromJSStringNullable()
     genNonNullString()
-    genStringEquals()
+    genEquals()
     genArrayEquals()
   }
 
@@ -2387,54 +2387,37 @@ object CoreWasmLib {
     fb.buildAndAddToModule()
   }
 
-  private def genStringEquals()(implicit ctx: WasmContext): Unit = {
+  // Generate a function that checks two given `anyref` values.
+  // If either of them is a `(ref null i16Array)`, convert it to a JS string
+  // and then compare. This ensures that the same string in different representations
+  // (i16Array vs JS string) returns true.
+  // Otherwise, use the JS function `Object.is` for comparison.
+  private def genEquals()(implicit ctx: WasmContext): Unit = {
     val fb = newFunctionBuilder(genFunctionID.equals)
-    val str1Param = fb.addParam("str1", RefType.anyref)
-    val str2Param = fb.addParam("str2", RefType.anyref)
+    val x1Param = fb.addParam("x1", RefType.anyref)
+    val x2Param = fb.addParam("x2", RefType.anyref)
     fb.setResultType(Int32)
 
-    fb.block(Int32) { doneLabel =>
-      // Block to handle the case where both are i16Array
-      fb.block(RefType.anyref) { notBothArray =>
-        fb += LocalGet(str1Param)
-        fb += BrOnCastFail(
-          notBothArray,
-          RefType.anyref,
-          RefType.nullable(genTypeID.i16Array)
-        )
-        fb += LocalGet(str2Param)
-        fb += BrOnCastFail(
-          notBothArray,
-          RefType.anyref,
-          RefType.nullable(genTypeID.i16Array)
-        )
-        fb += Call(genFunctionID.arrayEquals)
-        fb += Br(doneLabel)
-      } // end of block notBothArray
-      fb += Drop
+    fb.block(RefType.anyref) { labelDone =>
+      fb += LocalGet(x1Param)
+      fb += BrOnCastFail(
+        labelDone,
+        RefType.anyref,
+        RefType.nullable(genTypeID.i16Array)
+      )
+      fb += Call(genFunctionID.createJSStringFromArrayNullable)
+    }
 
-      // Block to handle the case where both are JS string
-      fb.block(RefType.nullable(genTypeID.i16Array)) { notBothJS =>
-        fb += LocalGet(str1Param)
-        fb += BrOnCast(
-          notBothJS,
-          RefType.anyref,
-          RefType.nullable(genTypeID.i16Array)
-        )
-        fb += LocalGet(str2Param)
-        fb += BrOnCast(
-          notBothJS,
-          RefType.anyref,
-          RefType.nullable(genTypeID.i16Array)
-        )
-        fb += Call(genFunctionID.is)
-        fb += Br(doneLabel)
-      } // end of block notBothJS
-      fb += Drop
-
-      // i16Array vs JS String, return 0 (false)
-      fb += I32Const(0)
-    } // end of block doneLabel
+    fb.block(RefType.anyref) { labelDone =>
+      fb += LocalGet(x2Param)
+      fb += BrOnCastFail(
+        labelDone,
+        RefType.anyref,
+        RefType.nullable(genTypeID.i16Array)
+      )
+      fb += Call(genFunctionID.createJSStringFromArrayNullable)
+    }
+    fb += Call(genFunctionID.is)
 
     fb.buildAndAddToModule()
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -228,7 +228,7 @@ final class Emitter(config: Emitter.Config) {
         case ModuleInitializerImpl.MainMethodWithArgs(className, encodedMainMethodName, args) =>
           val stringArrayTypeRef = ArrayTypeRef(ClassRef(BoxedStringClass), 1)
           SWasmGen.genArrayValue(fb, stringArrayTypeRef, args.size) {
-            args.foreach(arg => fb ++= ctx.stringPool.getConstantStringInstr(arg))
+            args.foreach(arg => fb ++= ctx.stringPool.getConstantJSStringInstr(arg))
           }
           genCallStatic(className, encodedMainMethodName)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -936,7 +936,7 @@ private class FunctionEmitter private (
             case SpecialNames.hashCodeMethodName =>
               fb += wa.Call(genFunctionID.identityHashCode)
             case `equalsMethodName` =>
-              fb += wa.Call(genFunctionID.equals)
+              fb += wa.Call(genFunctionID.is)
             case _ =>
               genHijackedClassCall(ObjectClass)
           }
@@ -2815,7 +2815,7 @@ private class FunctionEmitter private (
               fb += wa.BrIf(label)
             case StringLiteral(value) =>
               fb ++= ctx.stringPool.getConstantStringInstr(value)
-              fb += wa.Call(genFunctionID.equals)
+              fb += wa.Call(genFunctionID.is)
               fb += wa.BrIf(label)
             case Null() =>
               fb += wa.RefIsNull

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -897,7 +897,9 @@ private class FunctionEmitter private (
           pushArgs(argsLocals)
           genHijackedClassCall(BoxedDoubleClass)
         } else if (receiverClassName == CharSequenceClass) {
-          // the value must be a `string`; it already has the right type
+          // the value must be a `string` (in js string representation);
+          // here we need to convert to i16Array to invoke a String method
+          fb += wa.Call(genFunctionID.createArrayFromJSString)
           pushArgs(argsLocals)
           genHijackedClassCall(BoxedStringClass)
         } else if (methodName == compareToMethodName) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -936,7 +936,7 @@ private class FunctionEmitter private (
             case SpecialNames.hashCodeMethodName =>
               fb += wa.Call(genFunctionID.identityHashCode)
             case `equalsMethodName` =>
-              fb += wa.Call(genFunctionID.is)
+              fb += wa.Call(genFunctionID.equals)
             case _ =>
               genHijackedClassCall(ObjectClass)
           }
@@ -2815,7 +2815,7 @@ private class FunctionEmitter private (
               fb += wa.BrIf(label)
             case StringLiteral(value) =>
               fb ++= ctx.stringPool.getConstantStringInstr(value)
-              fb += wa.Call(genFunctionID.is)
+              fb += wa.Call(genFunctionID.equals)
               fb += wa.BrIf(label)
             case Null() =>
               fb += wa.RefIsNull

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1690,6 +1690,7 @@ private class FunctionEmitter private (
     val ctorName = MethodName.constructor(List(ClassRef(BoxedStringClass)))
     genNewScalaClass(ArithmeticExceptionClass, ctorName) {
       fb ++= ctx.stringPool.getConstantStringInstr("/ by zero")
+      fb += wa.Call(genFunctionID.createArrayFromJSString)
     }
     fb += wa.ExternConvertAny
     fb += wa.Throw(genTagID.exception)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1050,6 +1050,12 @@ private class FunctionEmitter private (
           case Some(primReceiverType) =>
             if (receiver.tpe == primReceiverType) {
               genTreeAuto(receiver)
+            } else if (
+              receiver.tpe == ClassType(BoxedStringClass) &&
+              primReceiverType == StringType
+            ) {
+              genTreeAuto(receiver)
+              fb += wa.RefAsNonNull
             } else {
               genTree(receiver, AnyType)
               fb += wa.RefAsNonNull
@@ -1558,8 +1564,7 @@ private class FunctionEmitter private (
             fb += wa.Call(genFunctionID.booleanToString)
             fb += wa.Call(genFunctionID.createArrayFromJSString)
           case CharType =>
-            fb += wa.Call(genFunctionID.charToString)
-            fb += wa.Call(genFunctionID.createArrayFromJSString)
+            fb += wa.ArrayNewFixed(genTypeID.i16Array, 1)
           case ByteType | ShortType | IntType =>
             fb += wa.Call(genFunctionID.intToString)
             fb += wa.Call(genFunctionID.createArrayFromJSString)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -931,7 +931,7 @@ private class FunctionEmitter private (
             // case JSValueTypeString =>
             List(JSValueTypeString) -> { () =>
               fb += wa.LocalGet(receiverLocal)
-              // no need to unbox for string
+              fb += wa.Call(genFunctionID.createArrayFromJSString)
               pushArgs(argsLocals)
               genHijackedClassCall(BoxedStringClass)
             }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -2618,34 +2618,6 @@ private class FunctionEmitter private (
               case watpe.RefType.anyref =>
                 // nothing to do
                 ()
-              // If it is a StringType or ClassType(BoxedStringClass),
-              // ArraySelect would expect to return `ref (null)? i16Array`.
-              // However, the elements of Array[String] can be either i16Array or a JS string because:
-              // - When creating a new Array[String](...), the elements are upcast to Any(?),
-              //   and converted to JSString upon the creation of the Array.
-              // - Assigning to the Array doesn't upcast(?) and the elements remain as i16Array.
-              //   For example, `java.util.regex.Pattern.split` builds result array by
-              //   ```
-              //   val r = new Array[String](actualLength)
-              //   for (i <- 0 until actualLength)
-              //     r(i) = result(i) // it doesn't convert to js string
-              //   ```
-              //
-              // Therefore, when selecting a String from an Array, unify them to be i16Array.
-              case watpe.RefType(_, heapType) if heapType == watpe.HeapType(genTypeID.i16Array) =>
-                // TODO: should we handle nullable?
-                val local = addSyntheticLocal(watpe.RefType.anyref)
-                fb += wa.LocalSet(local)
-                fb.block(watpe.RefType.nullable(genTypeID.i16Array)) { labelDone =>
-                  fb += wa.LocalGet(local)
-                  fb += wa.BrOnCast(
-                    labelDone,
-                    watpe.RefType.anyref,
-                    watpe.RefType.nullable(genTypeID.i16Array)
-                  )
-                  fb += wa.Call(genFunctionID.createArrayFromJSStringNullable)
-                }
-
               case refType: watpe.RefType =>
                 fb += wa.RefCast(refType)
               case otherType =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1201,7 +1201,7 @@ private class FunctionEmitter private (
 
       // String.length
       case String_length =>
-        fb += wa.Call(genFunctionID.stringLength)
+        fb += wa.ArrayLen
     }
 
     tree.tpe
@@ -1293,7 +1293,7 @@ private class FunctionEmitter private (
         genTree(lhs, StringType)
         genTree(rhs, IntType)
         markPosition(tree)
-        fb += wa.Call(genFunctionID.stringCharAt)
+        fb += wa.ArrayGetU(genTypeID.i16Array)
         CharType
 
       case _ =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -318,9 +318,9 @@ export async function load(wasmFileURL, importedModules, exportSetters) {
     const { readFile } = await import("node:fs/promises");
     const wasmPath = fileURLToPath(resolvedURL);
     const body = await readFile(wasmPath);
-    return WebAssembly.instantiate(body, importsObj);
+    return WebAssembly.instantiate(body, importsObj, { builtins: ['js-string'] });
   } else {
-    return await WebAssembly.instantiateStreaming(fetch(resolvedURL), importsObj);
+    return await WebAssembly.instantiateStreaming(fetch(resolvedURL), importsObj, { builtins: ['js-string'] });
   }
 }
     """

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -116,14 +116,14 @@ object SWasmGen {
       implicit ctx: WasmContext): Unit = {
     def genFollowPath(path: List[String]): Unit = {
       for (prop <- path) {
-        fb ++= ctx.stringPool.getConstantStringInstr(prop)
+        fb ++= ctx.stringPool.getConstantJSStringInstr(prop)
         fb += Call(genFunctionID.jsSelect)
       }
     }
 
     loadSpec match {
       case JSNativeLoadSpec.Global(globalRef, path) =>
-        fb ++= ctx.stringPool.getConstantStringInstr(globalRef)
+        fb ++= ctx.stringPool.getConstantJSStringInstr(globalRef)
         fb += Call(genFunctionID.jsGlobalRefGet)
         genFollowPath(path)
       case JSNativeLoadSpec.Import(module, path) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/StringPool.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/StringPool.scala
@@ -59,6 +59,9 @@ private[wasmemitter] final class StringPool {
   def getConstantStringInstr(str: String): List[Instr] =
     getConstantStringDataInstr(str) :+ Call(genFunctionID.stringLiteral)
 
+  def getConstantJSStringInstr(str: String): List[Instr] =
+    getConstantStringInstr(str) :+ Call(genFunctionID.createJSStringFromArray)
+
   /** Returns the list of 3 constant integers that must be passed to `stringLiteral`.
    *
    *  The resulting list is a Wasm constant expression, and hence can be used

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
@@ -66,9 +66,12 @@ object TypeTransformer {
    */
   def transformType(tpe: Type)(implicit ctx: WasmContext): watpe.Type = {
     tpe match {
+      case ClassType(className) if className == BoxedStringClass => watpe.RefType.nullable(genTypeID.i16Array)
+      case StringType             => watpe.RefType(genTypeID.i16Array)
+
       case AnyType                => watpe.RefType.anyref
       case ClassType(className)   => transformClassType(className)
-      case StringType | UndefType => watpe.RefType.any
+      case UndefType              => watpe.RefType.any
       case tpe: PrimTypeWithRef   => transformPrimType(tpe)
 
       case tpe: ArrayType =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -86,6 +86,11 @@ object VarGen {
 
     case object start extends FunctionID
 
+    // js string builtins
+
+    case object fromCharCodeArray extends FunctionID
+    case object intoCharCodeArray extends FunctionID
+
     // JS helpers
 
     /** A `FunctionID` for a JS helper function.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -91,6 +91,16 @@ object VarGen {
     case object fromCharCodeArray extends FunctionID
     case object intoCharCodeArray extends FunctionID
 
+    // wasm native strings
+    case object wasmStringConcat extends FunctionID
+    case object createArrayFromJSString extends FunctionID
+    case object createArrayFromJSStringNullable extends FunctionID
+    case object createJSStringFromArray extends FunctionID
+    case object createJSStringFromArrayNullable extends FunctionID
+    case object nonNullString extends FunctionID
+    case object arrayEquals extends FunctionID
+    case object equals extends FunctionID
+
     // JS helpers
 
     /** A `FunctionID` for a JS helper function.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -97,6 +97,7 @@ object VarGen {
     case object createArrayFromJSStringNullable extends FunctionID
     case object createJSStringFromArray extends FunctionID
     case object createJSStringFromArrayNullable extends FunctionID
+    case object maybeCreateJSStringFromArray extends FunctionID
     case object nonNullString extends FunctionID
     case object arrayEquals extends FunctionID
     case object equals extends FunctionID

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2028,7 +2028,10 @@ object Build {
       exampleSettings,
       name := "Hello World - Scala.js example",
       moduleName := "helloworld",
-      scalaJSUseMainModuleInitializer := true
+      scalaJSUseMainModuleInitializer := true,
+     scalaJSLinkerConfig ~= {
+        _.withPrettyPrint(true)
+      },
   ).withScalaJSCompiler.dependsOnLibrary
 
   lazy val reversi: MultiScalaProject = MultiScalaProject(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -261,6 +261,7 @@ object MyScalaJSPlugin extends AutoPlugin {
         val config = if (enableWasmEverywhere.value) {
           baseConfig.withArgs(List(
             "--experimental-wasm-exnref",
+            "--experimental-wasm-imported-strings",
             /* Force using the Turboshaft infrastructure for the optimizing compiler.
              * It appears to be more stable for the Wasm that we throw at it.
              * If you remove it, try running `scalaTestSuite2_13/test` with Wasm.


### PR DESCRIPTION

In the previous attempt https://gist.github.com/tanishiking/34fae60efade961406fe252c1be9ac91

<details>
<summary>Solved issues</summary>
we had some problems around `Array`.

## Problem
The problem was, the elements of String arrays constructed from `Array[String](...)` versus `"asdf".split` would not be identical, for instance

```scala
val a1 = Array[String]("a", "s", "d", "f")
val a2 = "asdf".split("")
a1(0) == a2(0) // -> false
// because a1 is JS string, and a2 is `i16Array`
```

It turned out the root cause of this difference is that, the string representation of elements of `Array[String]` depends on the way we construct the Array.

`Array[String]("a", "s", "d", "f")` will be compiled to the following Wasm code, each String element is converted to JSString by `genAdapt` because the `expectedType` is `AnyType` (right?)

```wasm
     i32.const 622
     i32.const 1
     i32.const 34
     call $stringLiteral
     call $createArrayFromJSString
     call $createJSStringFromArray
     ;; ...
     array.new_fixed $anyArray 4
     struct.new $ObjectArray
```

On the other hand, `"asdf".split("")` constructs the Array like following:

```scala
// java.util.regex.Pattern.split
      // Build result array
      val r = new Array[String](actualLength)
      for (i <- 0 until actualLength)
        r(i) = result(i)
      r
```
https://github.com/scala-js/scala-js/blob/e5f37ce97ea1297244ade0f7d1c9d8980b4fb12a/javalib/src/main/scala/java/util/regex/Pattern.scala#L179-L216

```wasm
        ;;       val r = new Array[String](actualLength)
        global.get $d.java.lang.String
        i32.const 1
        call $arrayTypeData
        global.get $arrayClassITable
        local.get $actualLength
        array.new_default $anyArray
        struct.new $ObjectArray
        local.set $r
       ;; ... passing this $r to p.java.util.regex.Pattern.$anonfun$java$util$regex$Pattern$$split

  (func $p.java.util.regex.Pattern.$anonfun$java$util$regex$Pattern$$split$1__Ljava.lang.String_Ljava.lang.Object_I_V (type $523)
     (param $this (ref $c.java.util.regex.Pattern)) (param $r$1 (ref null $ObjectArray)) (param $result$1 anyref) (param $i i32)
    
     local.get $r$1
     struct.get $ObjectArray $arrayUnderlying
     local.get $i
     local.get $result$1
     local.get $i
     call $bI
     call $jsSelect
     call $createArrayFromJSStringNullable
     array.set $anyArray)
```

As we can see, `r(i) = result(i)` compiles to `$jsSelect, $createArrayFromJSStringNullable, and array.set $anyArray`.

- We convert back to `i16Array` because `$result` is `js.Array[String]()`, and taking an element from it involves a downcast from Any to String.
- We don't convert to JSString because `r(i) = result(i)` doesn't involve an upcast from String to Any.

As a result, the elements of these two arrays differ: JSString vs i16Array."

## Solution1

To ensure that `a1(0) == a2(0)` evaluates to true, one solution is to align the String representation to i16Array when extracting an element from the array.

https://github.com/tanishiking/scala-js/pull/3/commits/a39439ded8ceaf17d447c324dc2a43a72e9593bb

With this change `a1(0) == a2(0)` became `true`.

## Solution2

The solution1 isn't perfect, `java.util.Arrays.deepEquals` between `a1` and `a2` are still `false`

```scala
val b1 = Array[AnyRef]("a", "s", "d", "f")
val b2 = erased("asdf".split(""))
java.util.Arrays.deepEquals(b1, b2) // -> false

def erased(array: Array[String]): Array[Object] =
  array.asInstanceOf[Array[AnyRef]]
```

In `java.util.Arrays.deepEquals`, it takes an element of arrays in

```scala
      while (i != len) {
        if (!Objects.deepEquals(a1(i), a2(i)))
          return false
        i += 1
      }
```
https://github.com/scala-js/scala-js/blob/53da391f09eb05542ec55e1ec9c58d230b61198f/javalib/src/main/scala/java/util/Arrays.scala#L613-L617

and it compiles to

```wasm
            call $m.java.util.Objects$
            ref.as_non_null
            local.get $a1
            struct.get $ObjectArray $arrayUnderlying
            local.get $i
            array.get $anyArray
            
            local.get $a2
            struct.get $ObjectArray $arrayUnderlying
            local.get $i
            array.get $anyArray
            call $f.java.util.Objects$.deepEquals_Ljava.lang.Object_Ljava.lang.Object_Z
```

As we can see, it doesn't convert to i16Array (using solution 1), because the type of `ArraySelect` isn't String (since we take an element in the context of `Objects.equals`, which accepts Any values ?)

Therefore, the solution2 would be comparing the identical JSString vs i16Array string to be true: https://github.com/tanishiking/scala-js/pull/3/commits/e5f37ce97ea1297244ade0f7d1c9d8980b4fb12a

define the following `$equals` function and use it instead of `$is`.
```wasm
  (func $equals (type $144)
     (param $x1 anyref) (param $x2 anyref) (result i32)
    
     block $1 (result anyref)
       local.get $x1
       br_on_cast_fail $1 anyref (ref null $i16Array)
       call $createJSStringFromArrayNullable
     end
     block $2 (result anyref)
       local.get $x2
       br_on_cast_fail $2 anyref (ref null $i16Array)
       call $createJSStringFromArrayNullable
     end
     call $is)
```

With this change, we could make `deepEquals(a1, a2)` to be `true` (maybe we no longer need an solution1)

## solution3 (?)

While solution 2 resolves the immediate issue, I'm not sure if making comparisons between JSString and i16Array return true is the right approach. It seems more appropriate to ensure that elements of string arrays are consistently represented as i16Array, though I'm not sure how to implement that.




---

With this change, `testSuite2_12 / Test / fastLinkJS` started to fail with 

```
[error] (testSuite2_12 / Test / fastLinkJS) java.util.NoSuchElementException: key not found: forMethod(org.scalajs.ir.Trees$MemberNamespace@0,ClassName<java.lang.String>,MethodName<clone;Ljava.lang.Object>)
```

in `BinaryWriter`, I have no idea how this change reads to the access to `java.lang.String.clone` 🤔 do you have any idea?

It would be somewhere around `genApplyWithDispatch`? https://github.com/tanishiking/scala-js/pull/3/files#diff-a5620481c5af54fff373d5042c2810a48b1ff7cf1a113ee4a98fc999bdce7b10R854 ?

</details>
